### PR TITLE
Add AGENTS.md and fix missing eslint-config-prettier dependency

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repository contains two parts:
+
+1. **Root (`/workspace`)** — A publishable npm package (React component library) bundled with webpack. Exports `ToastProvider`, `useToast`, and `TOAST_TYPES`.
+2. **`/workspace/react-toastified/`** — A Next.js 13.5 Pages Router demo app used for local development and visual testing of the toast component.
+
+### Running services
+
+| Service | Directory | Command | Port |
+|---------|-----------|---------|------|
+| Next.js demo app | `react-toastified/` | `npm run dev` | 3000 |
+| Webpack library build | `/workspace` | `npm run build` | N/A |
+
+### Key caveats
+
+- **ESLint config issue**: The demo app's `.eslintrc.json` extends `"next/babel"` which is a Babel preset, not an ESLint config. Running `next lint` fails due to this pre-existing config issue. The library build and dev server work fine regardless.
+- **No external services needed**: No databases, Docker, or environment variables are required. This is a purely frontend React component library.
+- **Jest**: Test runner is configured in root `package.json` (`npm test`) but no test files currently exist. Jest passes with `--passWithNoTests`.
+- **Peer dependency**: The root library lists `react ^18.2.0` as a peer dependency — it does not bundle React itself.
+- **Two `package.json` files**: Root is for the npm library package; `react-toastified/` is for the Next.js demo app. Both need `npm install` separately.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-toastified",
-  "version": "1.3.3",
+  "version": "1.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-toastified",
-      "version": "1.3.3",
+      "version": "1.3.7",
       "license": "ISC",
       "devDependencies": {
         "@babel/core": "^7.23.0",

--- a/react-toastified/package-lock.json
+++ b/react-toastified/package-lock.json
@@ -22,6 +22,7 @@
         "cssnano": "^6.0.1",
         "eslint": "^8",
         "eslint-config-next": "13.5.4",
+        "eslint-config-prettier": "^10.1.8",
         "next": "^13.5.4",
         "postcss": "^8",
         "postcss-cli": "^10.1.0",
@@ -2499,6 +2500,22 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-import-resolver-node": {

--- a/react-toastified/package.json
+++ b/react-toastified/package.json
@@ -47,6 +47,7 @@
     "cssnano": "^6.0.1",
     "eslint": "^8",
     "eslint-config-next": "13.5.4",
+    "eslint-config-prettier": "^10.1.8",
     "next": "^13.5.4",
     "postcss": "^8",
     "postcss-cli": "^10.1.0",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud specific development environment instructions for future agents.

## What's included

- Service descriptions and how to run them (Next.js demo app, webpack library build)
- Key caveats (ESLint config issue, no external services needed, Jest status, peer dependencies)
- Notes about the two `package.json` files and their relationship

## Walkthrough

[demo_toast_notifications.mp4](https://cursor.com/agents/bc-79091550-a79c-4356-a9aa-19a33177ac46/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_toast_notifications.mp4)

Demo showing all four toast notification types (info, success, error, warning) working in the Next.js development app.

[App loaded showing React-Toastified UI](https://cursor.com/agents/bc-79091550-a79c-4356-a9aa-19a33177ac46/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fapp_loaded.webp)
[Warning toast notification demo](https://cursor.com/agents/bc-79091550-a79c-4356-a9aa-19a33177ac46/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftoast_warning_demo.webp)

## Verification

- ✅ `npm install` (root) — dependencies installed successfully
- ✅ `npm install` (react-toastified/) — dependencies installed successfully
- ✅ `npm run build` (root) — webpack compiles successfully
- ✅ `npm test` (root) — jest passes with no tests
- ✅ `npm run dev` (react-toastified/) — Next.js dev server starts on port 3000
- ⚠️ `next lint` — pre-existing config issue with `next/babel` in `.eslintrc.json`

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-79091550-a79c-4356-a9aa-19a33177ac46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-79091550-a79c-4356-a9aa-19a33177ac46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

